### PR TITLE
fix: PHPStan 2.0 compatibility - use RuleErrorBuilder instead of string returns

### DIFF
--- a/src/Rules/Exceptions/EmptyExceptionRule.php
+++ b/src/Rules/Exceptions/EmptyExceptionRule.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt\Catch_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use function strpos;
 
 /**
@@ -23,13 +24,14 @@ class EmptyExceptionRule implements Rule
     /**
      * @param \PhpParser\Node\Stmt\Catch_ $node
      * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
+     * @return \PHPStan\Rules\RuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
         if ($this->isEmpty($node->stmts)) {
             return [
-                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.'
+                RuleErrorBuilder::message('Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.')
+                    ->build()
             ];
         }
 

--- a/src/Rules/Exceptions/MustRethrowRule.php
+++ b/src/Rules/Exceptions/MustRethrowRule.php
@@ -12,6 +12,7 @@ use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use RuntimeException;
 use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
 use Throwable;
@@ -32,7 +33,7 @@ class MustRethrowRule implements Rule
     /**
      * @param Catch_ $node
      * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
+     * @return \PHPStan\Rules\RuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -82,7 +83,8 @@ class MustRethrowRule implements Rule
         $errors = [];
 
         if (!$visitor->isThrowFound()) {
-            $errors[] = sprintf('%scaught "%s" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud', PrefixGenerator::generatePrefix($scope), $exceptionType);
+            $errors[] = RuleErrorBuilder::message(sprintf('%scaught "%s" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud', PrefixGenerator::generatePrefix($scope), $exceptionType))
+                ->build();
         }
 
         return $errors;


### PR DESCRIPTION
## Summary
Fixes PHPStan 2.0 compatibility issues in exception rules by using proper `RuleErrorBuilder` instead of string returns.

## Problem
- PHPStan 2.0 expects rules to return `RuleError[]` objects, not `string[]`
- `EmptyExceptionRule` and `MustRethrowRule` were causing internal transformer errors
- Error: `RuleErrorTransformer::transform(): Argument #1 ($ruleError) must be of type PHPStan\Rules\RuleError, string given`

## Solution
- Updated both rules to use `RuleErrorBuilder::message()->build()` pattern
- Added proper import for `PHPStan\Rules\RuleErrorBuilder`
- Maintains existing rule functionality and error messages
- Preserves backward compatibility

## Test plan
- [x] Verified PHPStan 2.0 no longer throws internal errors
- [x] Confirmed rules still detect and report violations correctly
- [x] Tested with existing codebase - rules work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)